### PR TITLE
Update to Spring-Security 4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
 	<groupId>com.auth0</groupId>
   <artifactId>spring-security-auth0</artifactId>
-  <version>0.3-SNAPSHOT</version>
+  <version>0.4-SNAPSHOT</version>
   <name>spring-security-auth0</name>
   <url>http://auth0.com</url>
   <packaging>jar</packaging>
@@ -17,9 +17,9 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<spring.version>3.2.8.RELEASE</spring.version>
+		<spring.version>4.0.3.RELEASE</spring.version>
 		<project.version>${project.version}</project.version>
-		<spring-security.version>3.2.4.RELEASE</spring-security.version>
+		<spring-security.version>4.0.3.RELEASE</spring-security.version>
     <java.version>1.6</java.version>
 	</properties>
 

--- a/src/main/resources/auth0-security-context.xml
+++ b/src/main/resources/auth0-security-context.xml
@@ -2,14 +2,14 @@
 	xmlns:security="http://www.springframework.org/schema/security"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-http://www.springframework.org/schema/beans/spring-beans-3.2.xsd
+http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
 http://www.springframework.org/schema/security
-http://www.springframework.org/schema/security/spring-security-3.2.xsd">
+http://www.springframework.org/schema/security/spring-security-4.0.xsd">
 
 	<bean id="auth0EntryPoint" class="com.auth0.spring.security.auth0.Auth0AuthenticationEntryPoint" />
 
 	<!-- all urls starting with unsecured are -->
-	<security:http pattern="${auth0.securedRoute}" create-session="stateless"  entry-point-ref="auth0EntryPoint">
+	<security:http pattern="${auth0.securedRoute}" create-session="stateless"  entry-point-ref="auth0EntryPoint" use-expressions="false">
 		<security:intercept-url pattern="${auth0.securedRoute}" access="ROLE_USER" />
 		<security:custom-filter ref="auth0Filter" after="SECURITY_CONTEXT_FILTER" ></security:custom-filter>
 	</security:http>


### PR DESCRIPTION
Updated the context file to support the 4.0 schemas for beans and spring security. Also, pushed the project version up to 0.4. I had to turn off expression based role checks to keep the access element the same.