### PR TITLE
updated to work with latest java-jwt 2.1.0 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
 	<groupId>com.auth0</groupId>
   <artifactId>spring-security-auth0</artifactId>
-  <version>0.4-SNAPSHOT</version>
+  <version>0.5-SNAPSHOT</version>
   <name>spring-security-auth0</name>
   <url>http://auth0.com</url>
   <packaging>jar</packaging>
@@ -39,6 +39,13 @@
         <role>Developer Advocate</role>
       </roles>
     </developer>
+    <developer>
+      <name>Ashish Dasnurkar</name>
+      <id>ashishdasnurkar</id>
+      <roles>
+        <role>Developer</role>
+      </roles>
+    </developer>
   </developers>
 
   <scm>
@@ -53,9 +60,18 @@
 		<dependency>
 			<groupId>com.auth0</groupId>
 			<artifactId>java-jwt</artifactId>
-			<version>0.3</version>
+			<version>2.1.0</version>
 		</dependency>
-
+	    <dependency>
+	      <groupId>com.fasterxml.jackson.core</groupId>
+	      <artifactId>jackson-databind</artifactId>
+	      <version>2.0.1</version>
+	    </dependency>
+	    <dependency>
+	      <groupId>commons-codec</groupId>
+	      <artifactId>commons-codec</artifactId>
+	      <version>1.4</version>
+	    </dependency>
 		<!-- Servlet dependencies -->
 		<dependency>
 			<groupId>javax.servlet</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
 	<groupId>com.auth0</groupId>
   <artifactId>spring-security-auth0</artifactId>
-  <version>0.5-SNAPSHOT</version>
+  <version>0.4-SNAPSHOT</version>
   <name>spring-security-auth0</name>
   <url>http://auth0.com</url>
   <packaging>jar</packaging>

--- a/src/main/java/com/auth0/spring/security/auth0/Auth0AuthenticationProvider.java
+++ b/src/main/java/com/auth0/spring/security/auth0/Auth0AuthenticationProvider.java
@@ -6,6 +6,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.SignatureException;
 import java.util.Map;
 
+import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.InitializingBean;
@@ -14,6 +15,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 
 import com.auth0.jwt.JWTVerifier;
+import com.auth0.jwt.JWTVerifyException;
 
 /**
  * Class that verifies the JWT token and in case of beeing valid, it will set
@@ -70,6 +72,10 @@ public class Auth0AuthenticationProvider implements AuthenticationProvider,
 			logger.debug("IOException thrown while decoding JWT token "
 					+ e.getLocalizedMessage());
 			throw AUTH_ERROR;
+		} catch (JWTVerifyException e) {
+			logger.debug("JWTVerifyException thrown while decoding JWT token "
+					+ e.getLocalizedMessage());
+			throw AUTH_ERROR;
 		}
 	}
 
@@ -86,7 +92,7 @@ public class Auth0AuthenticationProvider implements AuthenticationProvider,
 			throw new RuntimeException(
 					"You must set which route pattern is used to check for users so that they must be authenticated");
 		}
-		jwtVerifier = new JWTVerifier(clientSecret, clientId);
+		jwtVerifier = new JWTVerifier(new Base64(true).decodeBase64(clientSecret), clientId);
 	}
 
 	public String getSecuredRoute() {

--- a/src/main/java/com/auth0/spring/security/auth0/Auth0TokenHelper.java
+++ b/src/main/java/com/auth0/spring/security/auth0/Auth0TokenHelper.java
@@ -2,7 +2,7 @@ package com.auth0.spring.security.auth0;
 
 public interface Auth0TokenHelper<T> {
 
-	public String generateToken(T object, int expiration); 
+	public String generateToken(T object, long expiration); 
 	public T decodeToken(String token);
 
 }

--- a/src/main/java/com/auth0/spring/security/auth0/impl/Auth0TokenHelperImpl.java
+++ b/src/main/java/com/auth0/spring/security/auth0/impl/Auth0TokenHelperImpl.java
@@ -33,7 +33,6 @@ public class Auth0TokenHelperImpl implements Auth0TokenHelper<Object>, Initializ
 		String payload, token;
 		try {
 		
-			new Base64(true);
 			JWTSigner jwtSigner = new JWTSigner(Base64.decodeBase64(clientSecret));
 			HashMap<String, Object> claims = new HashMap<String, Object>();
 			claims.putAll((Map)object);

--- a/src/main/java/com/auth0/spring/security/auth0/impl/Auth0TokenHelperImpl.java
+++ b/src/main/java/com/auth0/spring/security/auth0/impl/Auth0TokenHelperImpl.java
@@ -29,6 +29,8 @@ public class Auth0TokenHelperImpl implements Auth0TokenHelper<Object>, Initializ
 
 	@Override
 	public String generateToken(Object object, long expiration) {
+		
+		Assert.isInstanceOf(java.util.Map.class, object, "Claims object is not a java.util.Map");
 
 		String payload, token;
 		try {

--- a/src/main/java/com/auth0/spring/security/auth0/impl/Auth0TokenHelperImpl.java
+++ b/src/main/java/com/auth0/spring/security/auth0/impl/Auth0TokenHelperImpl.java
@@ -83,8 +83,6 @@ public class Auth0TokenHelperImpl implements Auth0TokenHelper<Object>, Initializ
 
 	@Override
 	public void afterPropertiesSet() throws Exception {
-		System.out.println("clientSecret:" + clientSecret);
-		System.out.println("clientId:" + clientId);
 		Assert.notNull(clientSecret, "The client secret is not set for " + this.getClass());
 		Assert.notNull(clientId, "The client id is not set for " + this.getClass());
 

--- a/src/test/java/com/auth0/spring/security/auth0/MVCBaseSecurityTest.java
+++ b/src/test/java/com/auth0/spring/security/auth0/MVCBaseSecurityTest.java
@@ -47,12 +47,12 @@ public abstract class MVCBaseSecurityTest {
 		this.mockMvc = webAppContextSetup(this.wac).addFilters(this.springSecurityFilterChain).build();
 	}
 
-	protected String generateTokenWithExpirationDate(int value, TimeUnit time) throws Exception {
+	protected String generateTokenWithExpirationDate(long value) throws Exception {
 		Map<String, String> map = new HashMap<String, String>();
 		map.put("email", "auth0@test.com");
-
+		map.put("email_verified", "true");
 		//TODO check int overflow???
-		return tokenHelper.generateToken(map, (int) time.toSeconds(value));
+		return tokenHelper.generateToken(map, value);
 
 	}
 

--- a/src/test/java/com/auth0/spring/security/auth0/MVCBaseSecurityTest.java
+++ b/src/test/java/com/auth0/spring/security/auth0/MVCBaseSecurityTest.java
@@ -48,9 +48,9 @@ public abstract class MVCBaseSecurityTest {
 	}
 
 	protected String generateTokenWithExpirationDate(long value) throws Exception {
-		Map<String, String> map = new HashMap<String, String>();
+		Map<String, Object> map = new HashMap<String, Object>();
 		map.put("email", "auth0@test.com");
-		map.put("email_verified", "true");
+		map.put("email_verified", true);
 		//TODO check int overflow???
 		return tokenHelper.generateToken(map, value);
 

--- a/src/test/java/com/auth0/spring/security/auth0/SecuredControllerTest.java
+++ b/src/test/java/com/auth0/spring/security/auth0/SecuredControllerTest.java
@@ -2,6 +2,8 @@ package com.auth0.spring.security.auth0;
 
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.util.Calendar;
+import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
@@ -20,17 +22,30 @@ public class SecuredControllerTest extends MVCBaseSecurityTest {
 
 	@Test
 	public void shouldReturn401ForATokenThatHasExpired() throws Exception {
-		callUrlWithToken("/secured", generateTokenWithExpirationDate(-1, TimeUnit.SECONDS)).andExpect(status().isUnauthorized());
+		Calendar c = Calendar.getInstance();
+		c.setTime(new Date());
+		c.add(Calendar.DATE, -1);
+		String token = generateTokenWithExpirationDate(c.getTimeInMillis() / 1000L);
+		callUrlWithToken("/secured", token).andExpect(status().isUnauthorized());
 	}
 
 	@Test
 	public void shouldReturn200ForAValidToken() throws Exception {
-		callUrlWithToken("/secured", generateTokenWithExpirationDate(1, TimeUnit.DAYS)).andExpect(status().isOk());
+		Calendar c = Calendar.getInstance();
+		c.setTime(new Date());
+		System.out.println(c.getTimeInMillis());
+		c.add(Calendar.DATE, 1);
+		System.out.println((int)c.getTimeInMillis());
+		callUrlWithToken("/secured", generateTokenWithExpirationDate(c.getTimeInMillis() / 1000L)).andExpect(status().isOk());
 	}
 
 	@Test
 	public void shouldReturn200ForAnUnsecuredUrl() throws Exception {
-		callUrlWithToken("/unsecured", generateTokenWithExpirationDate(1, TimeUnit.DAYS)).andExpect(status().isOk());
+		Calendar c = Calendar.getInstance();
+		c.setTime(new Date());
+		c.add(Calendar.DATE, 1);
+
+		callUrlWithToken("/unsecured", generateTokenWithExpirationDate(c.getTimeInMillis() / 1000L)).andExpect(status().isOk());
 	}
 
 }

--- a/src/test/java/com/auth0/spring/security/auth0/SecuredControllerTest.java
+++ b/src/test/java/com/auth0/spring/security/auth0/SecuredControllerTest.java
@@ -33,9 +33,7 @@ public class SecuredControllerTest extends MVCBaseSecurityTest {
 	public void shouldReturn200ForAValidToken() throws Exception {
 		Calendar c = Calendar.getInstance();
 		c.setTime(new Date());
-		System.out.println(c.getTimeInMillis());
 		c.add(Calendar.DATE, 1);
-		System.out.println((int)c.getTimeInMillis());
 		callUrlWithToken("/secured", generateTokenWithExpirationDate(c.getTimeInMillis() / 1000L)).andExpect(status().isOk());
 	}
 


### PR DESCRIPTION
Earlier spring-security-auth0 worked with java-jwt 0.3. java-jwt has come a long way since then with lot of bufixes and improvements. This PR updates spring-security-auth0 to work with java-jwt 2.1.0 version. This PR includes

- [x]  updates to pom.xml
- [x]  implementation changes required to work with java-jwt 2.1.0
- [x]  updated unit tests