### PR TITLE
Fixed the default Access-Control-Allow-Headers 

### DIFF
--- a/src/main/java/com/auth0/spring/security/auth0/Auth0CORSFilter.java
+++ b/src/main/java/com/auth0/spring/security/auth0/Auth0CORSFilter.java
@@ -17,7 +17,7 @@ public class Auth0CORSFilter implements Filter {
         response.setHeader("Access-Control-Allow-Origin", "*");
         response.setHeader("Access-Control-Allow-Methods", "POST, GET, OPTIONS, DELETE");
         response.setHeader("Access-Control-Max-Age", "3600");
-        response.setHeader("Access-Control-Allow-Headers", "Authorization");
+        response.setHeader("Access-Control-Allow-Headers", "Authorization, Content-Type, Content-Length, Accept, X-Requested-With, X-XSRF-TOKEN");
         if (request.getMethod().equals("OPTIONS")) {
             return;
         }


### PR DESCRIPTION
Added extra headers required by Chrome, Firefox and AngularJS (etc.) for non-GET CORS requests and features like X-XSRF-TOKEN based CSRF protection to work.  If only the "Authorization" header is allowed, as per the previous version, non-GET CORS requests will fail.